### PR TITLE
Disable mutations by default, add env variable to override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.0.3] - 2025-06-17
+
+- Add `ALLOW_MUTATIONS` environment variable to control mutation permissions (default: none)
+  - Supports values: `none`, `explicit`, `all`
+  - Replaces hardcoded `--allow-mutations all` behavior
+
 ## [1.0.2] - 2025-06-13
 
 - Fix invalid input schema for `GetHackerOneCurrentUser` tool (workaround for https://github.com/apollographql/apollo-mcp-server/issues/136)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A Docker image that provides access to HackerOne's GraphQL API through the Model
    docker run -i --rm \
      -e ENDPOINT="https://hackerone.com/graphql" \
      -e TOKEN="<your_base64_encoded_token>" \
+     -e ALLOW_MUTATIONS="none" \
      hackertwo/hackerone-graphql-mcp-server:latest
    ```
 
@@ -20,6 +21,10 @@ A Docker image that provides access to HackerOne's GraphQL API through the Model
 
 - `ENDPOINT`: GraphQL endpoint URL (default: https://hackerone.com/graphql)
 - `TOKEN`: Base64 encoded API token in format: `base64(username:api_key)`
+- `ALLOW_MUTATIONS`: Controls which mutations are allowed (default: none)
+  - `none`: No mutations allowed
+  - `explicit`: Only explicitly defined mutations allowed
+  - `all`: All mutations allowed
 
 ## Generating an API Token
 
@@ -42,6 +47,8 @@ A Docker image that provides access to HackerOne's GraphQL API through the Model
           "ENDPOINT=https://hackerone.com/graphql",
           "-e",
           "TOKEN=<your_base64_encoded_token>",
+          "-e",
+          "ALLOW_MUTATIONS=none",
           "hackertwo/hackerone-graphql-mcp-server:latest"
         ]
       },

--- a/entrypoint
+++ b/entrypoint
@@ -2,6 +2,20 @@
 
 # NOTE: Log level must be as high as possible to avoid breaking the stdio MCP protocol.
 
+# Set default value for ALLOW_MUTATIONS if not provided
+ALLOW_MUTATIONS="${ALLOW_MUTATIONS:-none}"
+
+# Validate ALLOW_MUTATIONS value
+case "$ALLOW_MUTATIONS" in
+  "none"|"explicit"|"all")
+    # Valid value, continue
+    ;;
+  *)
+    echo "Error: ALLOW_MUTATIONS must be one of: none, explicit, all. Got: $ALLOW_MUTATIONS" >&2
+    exit 1
+    ;;
+esac
+
 # https://www.apollographql.com/docs/apollo-mcp-server/command-reference
 /app/apollo-mcp-server --directory "/app/graphql" \
   --schema "schema.graphql" \
@@ -9,5 +23,5 @@
   --log error \
   --endpoint "${ENDPOINT}" \
   --header "Authorization: Bearer ${TOKEN}" \
-  --allow-mutations all \
+  --allow-mutations "$ALLOW_MUTATIONS" \
   "$@"


### PR DESCRIPTION
Having mutations enabled by default felt a little bit scary. This change makes sure we default to `none`, but also adds and environment variable that the user can use to override this behavior.