### PR TITLE
Reduce excess docker image creation

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -59,11 +59,8 @@ jobs:
         tags: |
           type=ref,event=pr
           type=semver,pattern={{version}}
-          type=semver,pattern={{major}}.{{minor}}
-          type=semver,pattern={{major}}
           type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-          type=raw,value=dev-{{sha}},enable={{is_default_branch}}
-          type=raw,value=dev-{{sha}},enable=${{ github.event.inputs.force_push == 'true' }}
+          type=raw,value=dev-main,enable={{is_default_branch}}
 
     - name: Build and push Docker image
       uses: docker/build-push-action@v5

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ A Docker image that provides access to HackerOne's GraphQL API through the Model
 ## Docker Image Tags
 
 - **`latest`**: Latest stable release (only updated on version releases)
-- **`dev-<commit>`**: Development builds from main branch (e.g., `dev-abc1234`)
-- **`v1.0.0`**: Specific version releases
+- **`dev-main`**: Development builds from main branch
+- **`1.x.x`**: Specific version releases
 - **`pr-<ref>`**: Pull request builds
 
 ## Environment Variables
@@ -78,7 +78,7 @@ A Docker image that provides access to HackerOne's GraphQL API through the Model
 
 To create a new release:
 
-1. Create a [new release in GitHub](https://github.com/Hacker0x01/hackerone-graphql-mcp-server/releases/new)
+1. Create a [new release in GitHub](https://github.com/Hacker0x01/hackerone-graphql-mcp-server/releases/new).
 
 2. GitHub Actions will automatically:
    - Build multi-architecture images (amd64, arm64)


### PR DESCRIPTION
This PR aims to reduce excess Docker image creation by updating the Docker image tag strategy and streamlining the workflow configuration.

Updated the Docker image tag names in the README to use "dev-main" and "1.x.x".
Simplified the Docker workflow by replacing commit-specific tags (e.g., "dev-{{sha}}") with a static tag ("dev-main").